### PR TITLE
Filter MSSQL non toplevel resources

### DIFF
--- a/state/filter.go
+++ b/state/filter.go
@@ -51,6 +51,9 @@ var resourcesOnlyMovedInTF = []string{
 	"azurerm_key_vault_secret",
 	"azurerm_storage_share",
 	"azurerm_subnet_network_security_group_association",
+	"azurerm_mssql_database",
+	"azurerm_mssql_database_extended_auditing_policy",
+	"azurerm_sql_virtual_network_rule",
 }
 
 var resourcesNotSupportedInAzure = []string{

--- a/state/filter.go
+++ b/state/filter.go
@@ -45,22 +45,22 @@ func (ris ResourcesInstanceSummary) ToCorrectInTFState() map[string]string {
 }
 
 var resourcesOnlyMovedInTF = []string{
-	"azurerm_mysql_firewall_rule",
 	"azurerm_key_vault_access_policy",
-	"azurerm_storage_container",
 	"azurerm_key_vault_secret",
-	"azurerm_storage_share",
-	"azurerm_subnet_network_security_group_association",
 	"azurerm_mssql_database",
 	"azurerm_mssql_database_extended_auditing_policy",
-	"azurerm_sql_virtual_network_rule",
+	"azurerm_mysql_firewall_rule",
+	"azurerm_sql_firewall_rule",
+	"azurerm_storage_container",
+	"azurerm_storage_share",
+	"azurerm_subnet_network_security_group_association",
 }
 
 var resourcesNotSupportedInAzure = []string{
-	"azurerm_kubernetes_cluster",
-	"azurerm_resource_group",
 	"azurerm_client_config",
+	"azurerm_kubernetes_cluster",
 	"azurerm_monitor_diagnostic_setting",
+	"azurerm_resource_group",
 }
 
 func (tfstate TerraformState) Filter(resourceFilter, moduleFilter, resourceGroupFilter, sourceSubscriptionID, targetResourceGroup, targetSubscriptionID string) (resourceInstances ResourcesInstanceSummary, sourceResourceGroup string, err error) {


### PR DESCRIPTION
Extra MSSQL resources added to move only in Terraform and ignore them on Azure. 